### PR TITLE
Handles URLs ending with a slash

### DIFF
--- a/client/utils.js
+++ b/client/utils.js
@@ -27,6 +27,10 @@ export function findSlug (programCard) {
 }
 
 export function extractSlugFromUrl (url) {
+  // Handle URLs ending with a slash by removing the slash if it exists
+  if (url.substring(url.length - 1) == '/') {
+    url = url.substring(0, url.length - 1)
+  }
   const parts = url.split('/')
   const last = parts[parts.length - 1]
   return last.replace(/#.*$/, '')


### PR DESCRIPTION
Now handles URLs that ends with a trailing slash, e.g. `https://www.dr.dk/tv/se/huset-pa-christianshavn/huset-pa-christianshavn-10/`.

Still doesn't handle URLs ending with a timestamp, e.g.`https://www.dr.dk/tv/se/huset-pa-christianshavn/huset-pa-christianshavn-5#!/00:01:355`.
